### PR TITLE
allow/disallow using cross faction mounts

### DIFF
--- a/lua_scripts/AccountWide/AccountMounts.lua
+++ b/lua_scripts/AccountWide/AccountMounts.lua
@@ -40,7 +40,6 @@ end
 -- class=15 subclass=5 (mount), spellid_1 is learning spell (483/55884), spellid_2 is the mount spell.
 local MOUNT_ID_SET, uniq_list = {}, {}
 do
-    -- Add AllowableRace to verify faction restriction
     local query = WorldDBQuery([[
         SELECT spellid_2, AllowableRace
           FROM item_template
@@ -65,7 +64,6 @@ do
                     if raceMask == -1 then
                         MOUNT_ID_SET[id] = -1
                     else
-                        -- bit_or is global Eluna function
                         MOUNT_ID_SET[id] = bit_or(MOUNT_ID_SET[id], raceMask)
                     end
                 end
@@ -137,21 +135,16 @@ local function LearnOwnedMountsNow(player, accountId)
 
     if next(ownedSet) == nil then return end
 
-    -- Learn only those the account owns (and this character doesn't yet have)
     local guid = player:GetGUIDLow()
-    
-    -- Calculates race mask (pow 2) 
-    --  Human (1) = 2^0 = 1 | Orc (2) = 2^1 = 2 | Dwarf (3) = 2^2 = 4, etc.
-    local playerRace = player:GetRace()
-    local playerRaceMask = 2 ^ (playerRace - 1)
+    local playerRaceMask = player:GetRaceMask()
 
+    -- Learn only those the account owns (and this character doesn't yet have)
     mountSyncInProgress[guid] = true
     local ok = pcall(function()
         for spellId in pairs(ownedSet) do
             if not player:HasSpell(spellId) then
                 local reqMask = MOUNT_ID_SET[spellId]
                 
-                -- Checks if faction restriction its enabled, if the mount is universal (-1) or if the race mask allows, using bit_and from Eluna
                 if not RESTRICT_BY_FACTION or reqMask == nil or reqMask == -1 or bit_and(reqMask, playerRaceMask) > 0 then
                     player:LearnSpell(spellId)
                 end

--- a/lua_scripts/AccountWide/AccountMounts.lua
+++ b/lua_scripts/AccountWide/AccountMounts.lua
@@ -14,6 +14,8 @@ local MIN_MOUNT_LEVEL = 11  -- Minimum character level before mounts are learned
 local RETROACTIVE_NOTIFY = true
 local RETROACTIVE_DELAY_MS = 150
 
+local RESTRICT_BY_FACTION = true  -- true: restrict mounts between ally/horde. false: all mounts available.
+
 ------------------------------------------------------------------------------------------------
 -- END CONFIG
 ------------------------------------------------------------------------------------------------
@@ -38,8 +40,9 @@ end
 -- class=15 subclass=5 (mount), spellid_1 is learning spell (483/55884), spellid_2 is the mount spell.
 local MOUNT_ID_SET, uniq_list = {}, {}
 do
+    -- Add AllowableRace to verify faction restriction
     local query = WorldDBQuery([[
-        SELECT DISTINCT spellid_2
+        SELECT spellid_2, AllowableRace
           FROM item_template
          WHERE class = 15
            AND subclass = 5
@@ -50,9 +53,22 @@ do
     if query then
         repeat
             local id = query:GetUInt32(0)
+            local raceMask = query:GetInt32(1)
+
             if id and id > 0 then
-                MOUNT_ID_SET[id] = true
-                uniq_list[#uniq_list+1] = id
+                if not MOUNT_ID_SET[id] then
+                    MOUNT_ID_SET[id] = raceMask
+                    uniq_list[#uniq_list+1] = id
+                elseif MOUNT_ID_SET[id] ~= -1 then
+                    -- If there are multiple items for the same spell, join permissions
+                    --  -1 equals all races (no restriction)
+                    if raceMask == -1 then
+                        MOUNT_ID_SET[id] = -1
+                    else
+                        -- bit_or is global Eluna function
+                        MOUNT_ID_SET[id] = bit_or(MOUNT_ID_SET[id], raceMask)
+                    end
+                end
             end
         until not query:NextRow()
     end
@@ -87,7 +103,7 @@ end
 
 local function OnLearnNewMount(event, player, spellID)
     -- Skip playerbot accounts
-    if AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
+    if AUtils and AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
 
     local accountId = player:GetAccountId()
     local guid = player:GetGUIDLow()
@@ -100,7 +116,6 @@ local function OnLearnNewMount(event, player, spellID)
 
         CharDBExecute(string.format("INSERT IGNORE INTO accountwide_mounts (accountId, mountSpellId) VALUES (%d, %d)", accountId, spellID))
 
-        -- Keep cache in sync
         if cached then
             cached[spellID] = true
         end
@@ -124,11 +139,22 @@ local function LearnOwnedMountsNow(player, accountId)
 
     -- Learn only those the account owns (and this character doesn't yet have)
     local guid = player:GetGUIDLow()
+    
+    -- Calculates race mask (pow 2) 
+    --  Human (1) = 2^0 = 1 | Orc (2) = 2^1 = 2 | Dwarf (3) = 2^2 = 4, etc.
+    local playerRace = player:GetRace()
+    local playerRaceMask = 2 ^ (playerRace - 1)
+
     mountSyncInProgress[guid] = true
     local ok = pcall(function()
         for spellId in pairs(ownedSet) do
             if not player:HasSpell(spellId) then
-                player:LearnSpell(spellId)
+                local reqMask = MOUNT_ID_SET[spellId]
+                
+                -- Checks if faction restriction its enabled, if the mount is universal (-1) or if the race mask allows, using bit_and from Eluna
+                if not RESTRICT_BY_FACTION or reqMask == nil or reqMask == -1 or bit_and(reqMask, playerRaceMask) > 0 then
+                    player:LearnSpell(spellId)
+                end
             end
         end
     end)
@@ -138,7 +164,7 @@ end
 
 local function SyncMountsToPlayer(event, player)
     -- Skip playerbot accounts
-    if AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
+    if AUtils and AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
 
     local accountId = player:GetAccountId()
     local playerLevel = player:GetLevel()
@@ -166,7 +192,7 @@ end
 
 local function OnSendLearnedSpell(event, packet, player)
     -- Skip playerbot accounts
-    if AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
+    if AUtils and AUtils.shouldSkipAll and AUtils.shouldSkipAll(player) then return end
 
     local spellId = packet:ReadULong()
     -- Apprentice Riding   Journeyman Riding   Expert Riding       Artisan Riding


### PR DESCRIPTION
What Changed in the Script?

    The Variable RESTRICT_BY_FACTION can now enable or disable some mounts that are based on character faction. 

    The initial WorldDBQuery now also fetches the AllowableRace field. We mapped this using bitwise operations (bit.bor) in Lua to cover cases where multiple items teach the same spell.

    In the LearnOwnedMountsNow function, before the character learns the mount spell saved on the account, we verify if the character's race mask (player:GetRace()) is compatible with the item's mask.